### PR TITLE
Preload json as "fetch"

### DIFF
--- a/final/firebase.json
+++ b/final/firebase.json
@@ -12,7 +12,7 @@
         "source": "/",
         "headers": [{
           "key": "Link",
-          "value": "</elements/my-app.js>;rel=preload;as=script,</style.css>;rel=preload;as=style,</elements/list-view.js>;rel=preload;as=script,</data/list.json>;rel=preload"
+          "value": "</elements/my-app.js>;rel=preload;as=script,</style.css>;rel=preload;as=style,</elements/list-view.js>;rel=preload;as=script,</data/list.json>;rel=preload;as=fetch"
         }]
       },
       {


### PR DESCRIPTION
Add a content type for the JSON file

Using "fetch" as per https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content

Fixes a warning in the console:
<link rel=preload> must have a valid `as` value